### PR TITLE
Install from r-universe

### DIFF
--- a/docker/R/convert-dp-dwca.R
+++ b/docker/R/convert-dp-dwca.R
@@ -3,11 +3,11 @@ library(camtrapdp)
 import_path <- "/R/dp"
 export_path <- "/R/dwca"
 
-#* Transforms the CameraTrap Data Package into DwC-A.
-#* @param dataset_key GBIF datset key
-#* @param dataset_title GBIF dataset title
-#* @get /to_dwca
-convertCamtrapDwca <- function(dataset_title="") {
+#' Transforms the Camera Trap Data Package into DwC-A
+#' 
+#' @param dataset_title GBIF dataset title.
+#' @get /to_dwca
+convertCamtrapDwca <- function(dataset_title = "") {
   if (!file_test("-d", import_path)) {
     stop(paste("Input path does not exist", import_path))
   }
@@ -25,7 +25,7 @@ convertCamtrapDwca <- function(dataset_title="") {
   unlink(export_path)
   camtrapdp::write_dwc(package, export_path)
 
-  # Copy meta.xml, this copied to the same directory where this script run in the docker image
+  # Copy meta.xml, this is copied to the same directory where this script run in the docker image
   file.copy("meta.xml", file.path(export_path, "meta.xml"))
 
   # Flush memory
@@ -35,7 +35,7 @@ convertCamtrapDwca <- function(dataset_title="") {
   return(sprintf("Dataset transformed"))
 }
 
-args = commandArgs(trailingOnly=TRUE)
+args = commandArgs(trailingOnly = TRUE)
 
 if (length(args) == 1) {
   convertCamtrapDwca(args[1])

--- a/docker/R/install_packages.R
+++ b/docker/R/install_packages.R
@@ -4,6 +4,6 @@
 # Install camtraptdp  from GitHub
 install.packages("devtools")
 devtools::install_github("inbo/camtrapdp", ref = "refs/tags/v0.3.0")
-if ( ! library("camtrapdp", character.only=TRUE, logical.return=TRUE) ) {
-  quit(status=1, save='no')
+if (!library("camtrapdp", character.only = TRUE, logical.return = TRUE)) {
+  quit(status = 1, save = "no")
 }

--- a/docker/R/install_packages.R
+++ b/docker/R/install_packages.R
@@ -1,9 +1,8 @@
-# Install camtrapdp from CRAN
-#install.packages("camtrapdp")
-
-# Install camtraptdp  from GitHub
-install.packages("devtools")
-devtools::install_github("inbo/camtrapdp", ref = "refs/tags/v0.3.0")
+# Install camtrapdp from r-universe
+install.packages(
+  "camtrapdp",
+  repos = c("https://inbo.r-universe.dev", "https://cloud.r-project.org")
+)
 if (!library("camtrapdp", character.only = TRUE, logical.return = TRUE)) {
   quit(status = 1, save = "no")
 }


### PR DESCRIPTION
This PR updates:

- Code style
- Installs camtrapdp from r-universe, which is similar to GitHub install but doesn't require an extra package

@mike-podolskiy90 At a later stage, we should install v0.4.0 (rather than from the main branch), but still through r-universe.